### PR TITLE
fix(Form): no more double encoding uri's

### DIFF
--- a/src/components/Form.svelte
+++ b/src/components/Form.svelte
@@ -12,7 +12,7 @@
   function handleSubmit() {
     isError = false
     if (isValidURL(url)) {
-      goto(`/${encodeURIComponent(url)}`, { replaceState: false })
+      goto(`/${url}`, { replaceState: false })
     } else {
       isError = true
     }


### PR DESCRIPTION
## Description

Before this changed was introduced, our `fetch` requests to our proxy would give a `404`, claiming that the URL provided was not valid. After a little bit of digging, it turns out that we don't need to use the `encodeURIComponent` in `Form.svelte`. Removing this fixes the issue and allows pages to render properly.

## Testing Strategy

Local dev env testing.

## Screenshots (if applicable)

N/A