### PR TITLE
cursor: Add AGENTS.md for cloud development environment setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,24 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+**Static Preview** is a client-side SvelteKit app that renders static websites from GitHub/GitLab repositories. No backend, no database, no Docker required.
+
+### Commands
+
+| Task | Command |
+|------|---------|
+| Install deps | `npm install` |
+| Dev server | `npm run dev` (serves on `http://localhost:3000`) |
+| Lint | `npm run lint` (prettier + eslint) |
+| Tests | `npm run test` (Jest — URL parsing only) |
+| Build | `npm run build` |
+| Type check | `npm run check` |
+
+### Notes
+
+- The `prepare` script (`svelte-kit sync`) runs automatically during `npm install`. If you see import errors for `$app/*` modules, re-run `npm install`.
+- The dev server uses port **3000** by default. Pass `--host 0.0.0.0` to expose it outside localhost: `npm run dev -- --host 0.0.0.0`.
+- Preview functionality depends on the external CORS proxy `api.codetabs.com`. If previews fail to load, this third-party service may be down.
+- `svelte-preprocess` deprecation warnings about "defaults" are expected and harmless.
+- The `package-lock.json` uses npm; do not mix with other package managers.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with Cursor Cloud specific instructions for future cloud agents working in this repository.

## What's included

- **`AGENTS.md`**: Documents key commands (dev server, lint, test, build, type check), port configuration, and non-obvious caveats (e.g. `svelte-kit sync` via `prepare` script, external CORS proxy dependency, expected deprecation warnings).

## Environment verification

All standard development workflows were verified:

| Check | Command | Status |
|-------|---------|--------|
| Install | `npm install` | Pass |
| Lint | `npm run lint` | Pass |
| Tests | `npm run test` (22 tests) | Pass |
| Build | `npm run build` | Pass |
| Dev server | `npm run dev` | Pass |
| Hello-world | Preview a GitHub repo with `index.html` | Pass |

### Demo

<a href="https://cursor.com/agents/bc-8d364c60-d99f-4bde-8f6f-87b730c3ce26/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstatic-preview-hello-world-demo.mp4"><img src="https://cursor.com/artifacts/c/art-cd356426-0890-4614-a8d7-c37f55864d15" alt="static-preview-hello-world-demo.mp4" /></a>

Entered `https://github.com/SirajChokshi/DelineatedTheme` and the app successfully fetched and rendered the static site.

![Preview result showing rendered DelineatedTheme](https://cursor.com/artifacts/c/art-a24cab14-6304-4a72-a978-39f9e4f218fd)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8d364c60-d99f-4bde-8f6f-87b730c3ce26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8d364c60-d99f-4bde-8f6f-87b730c3ce26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

