### PR TITLE
Fix direct encoded URL route returning 500

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,9 +7,6 @@
     "": {
       "name": "static-preview-svelte",
       "version": "2.0.0",
-      "dependencies": {
-        "logbench": "^0.0.2"
-      },
       "devDependencies": {
         "@babel/preset-env": "^7.29.2",
         "@eslint/js": "^8.57.1",
@@ -8019,12 +8016,6 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/logbench": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/logbench/-/logbench-0.0.2.tgz",
-      "integrity": "sha512-URmBgxR7kFfj7H3jr1iuVeivwinfpLKMpS1vt4yRbbAKYrULYqfColakkfNxPpCFLKjzUIXAxPgeTs0Vmayu7A==",
       "license": "MIT"
     },
     "node_modules/lru-cache": {

--- a/package.json
+++ b/package.json
@@ -51,8 +51,5 @@
     "typescript": "^5.9.3",
     "vite": "^8.0.5"
   },
-  "type": "module",
-  "dependencies": {
-    "logbench": "^0.0.2"
-  }
+  "type": "module"
 }

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -21,9 +21,9 @@ const formatMessage = (message: LogMessage): string => {
 }
 
 const styledLogger =
-  (logFn: (...data: unknown[]) => void, background: string, color: string) =>
+  (method: 'log' | 'warn' | 'error', background: string, color: string) =>
   (message: LogMessage): void => {
-    logFn(
+    console[method](
       `%c${formatMessage(message)}`,
       `
     font-size: 12px;
@@ -43,9 +43,9 @@ const logger: Logger = isProduction
       error: noop,
     }
   : {
-      log: styledLogger(console.log, 'black', 'white'),
-      warn: styledLogger(console.warn, '#200e00', '#feeada'),
-      error: styledLogger(console.error, '#4a0000', '#ffd7d7'),
+      log: styledLogger('log', 'black', 'white'),
+      warn: styledLogger('warn', '#200e00', '#feeada'),
+      error: styledLogger('error', '#4a0000', '#ffd7d7'),
     }
 
 export default logger

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,27 +1,51 @@
-import logbench from 'logbench'
+type LogMessage = unknown
 
-const logger = logbench({
-  logFn: (message) =>
+type Logger = {
+  log: (message: LogMessage) => void
+  warn: (message: LogMessage) => void
+  error: (message: LogMessage) => void
+}
+
+const noop = () => {}
+
+const formatMessage = (message: LogMessage): string => {
+  if (typeof message === 'string') {
+    return message
+  }
+
+  try {
+    return JSON.stringify(message, null, 2)
+  } catch {
+    return String(message)
+  }
+}
+
+const styledLogger =
+  (background: string, color: string) =>
+  (message: LogMessage): void => {
     console.log(
-      `%c${message}`,
+      `%c${formatMessage(message)}`,
       `
     font-size: 12px;
-    background: black;
-    color: white;
+    background: ${background};
+    color: ${color};
     padding: 5px;
    `,
-    ),
-  warnFn: (message) =>
-    console.log(
-      `%c${message}`,
-      `
-     font-size: 12px;
-     background: #200e00;
-     color: #feeada; 
-     padding: 5px;
-    `,
-    ),
-  isProduction: process.env.NODE_ENV === 'production',
-})
+    )
+  }
+
+const isProduction = process.env.NODE_ENV === 'production'
+
+const logger: Logger = isProduction
+  ? {
+      log: noop,
+      warn: noop,
+      error: noop,
+    }
+  : {
+      log: styledLogger('black', 'white'),
+      warn: styledLogger('#200e00', '#feeada'),
+      error: styledLogger('#4a0000', '#ffd7d7'),
+    }
 
 export default logger

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -21,9 +21,9 @@ const formatMessage = (message: LogMessage): string => {
 }
 
 const styledLogger =
-  (background: string, color: string) =>
+  (logFn: (...data: unknown[]) => void, background: string, color: string) =>
   (message: LogMessage): void => {
-    console.log(
+    logFn(
       `%c${formatMessage(message)}`,
       `
     font-size: 12px;
@@ -43,9 +43,9 @@ const logger: Logger = isProduction
       error: noop,
     }
   : {
-      log: styledLogger('black', 'white'),
-      warn: styledLogger('#200e00', '#feeada'),
-      error: styledLogger('#4a0000', '#ffd7d7'),
+      log: styledLogger(console.log, 'black', 'white'),
+      warn: styledLogger(console.warn, '#200e00', '#feeada'),
+      error: styledLogger(console.error, '#4a0000', '#ffd7d7'),
     }
 
 export default logger

--- a/tests/logger.test.ts
+++ b/tests/logger.test.ts
@@ -1,26 +1,43 @@
-import logger from '../src/utils/logger'
-
 describe('logger', () => {
   const originalNodeEnv = process.env.NODE_ENV
-  let logSpy: jest.SpyInstance
-  let warnSpy: jest.SpyInstance
-  let errorSpy: jest.SpyInstance
 
-  beforeEach(() => {
-    process.env.NODE_ENV = 'development'
-    logSpy = jest.spyOn(console, 'log').mockImplementation(() => {})
-    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
-    errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
-  })
+  const loadLoggerForNodeEnv = async (nodeEnv?: string) => {
+    jest.resetModules()
+
+    if (nodeEnv === undefined) {
+      delete process.env.NODE_ENV
+    } else {
+      process.env.NODE_ENV = nodeEnv
+    }
+
+    const loggerModule = await import('../src/utils/logger')
+
+    return loggerModule.default
+  }
+
+  const spyConsole = () => {
+    return {
+      logSpy: jest.spyOn(console, 'log').mockImplementation(() => {}),
+      warnSpy: jest.spyOn(console, 'warn').mockImplementation(() => {}),
+      errorSpy: jest.spyOn(console, 'error').mockImplementation(() => {}),
+    }
+  }
 
   afterEach(() => {
-    logSpy.mockRestore()
-    warnSpy.mockRestore()
-    errorSpy.mockRestore()
-    process.env.NODE_ENV = originalNodeEnv
+    jest.restoreAllMocks()
+    jest.resetModules()
+
+    if (originalNodeEnv === undefined) {
+      delete process.env.NODE_ENV
+    } else {
+      process.env.NODE_ENV = originalNodeEnv
+    }
   })
 
-  it('routes log messages to console.log', () => {
+  it('routes log messages to console.log', async () => {
+    const { logSpy, warnSpy, errorSpy } = spyConsole()
+    const logger = await loadLoggerForNodeEnv('development')
+
     logger.log('hello')
 
     expect(logSpy).toHaveBeenCalledTimes(1)
@@ -28,7 +45,10 @@ describe('logger', () => {
     expect(errorSpy).not.toHaveBeenCalled()
   })
 
-  it('routes warn messages to console.warn', () => {
+  it('routes warn messages to console.warn', async () => {
+    const { logSpy, warnSpy, errorSpy } = spyConsole()
+    const logger = await loadLoggerForNodeEnv('development')
+
     logger.warn('watch out')
 
     expect(warnSpy).toHaveBeenCalledTimes(1)
@@ -36,11 +56,27 @@ describe('logger', () => {
     expect(errorSpy).not.toHaveBeenCalled()
   })
 
-  it('routes error messages to console.error', () => {
+  it('routes error messages to console.error', async () => {
+    const { logSpy, warnSpy, errorSpy } = spyConsole()
+    const logger = await loadLoggerForNodeEnv('development')
+
     logger.error('boom')
 
     expect(errorSpy).toHaveBeenCalledTimes(1)
     expect(logSpy).not.toHaveBeenCalled()
     expect(warnSpy).not.toHaveBeenCalled()
+  })
+
+  it('is a no-op in production', async () => {
+    const { logSpy, warnSpy, errorSpy } = spyConsole()
+    const logger = await loadLoggerForNodeEnv('production')
+
+    logger.log('hello')
+    logger.warn('watch out')
+    logger.error('boom')
+
+    expect(logSpy).not.toHaveBeenCalled()
+    expect(warnSpy).not.toHaveBeenCalled()
+    expect(errorSpy).not.toHaveBeenCalled()
   })
 })

--- a/tests/logger.test.ts
+++ b/tests/logger.test.ts
@@ -1,0 +1,46 @@
+import logger from '../src/utils/logger'
+
+describe('logger', () => {
+  const originalNodeEnv = process.env.NODE_ENV
+  let logSpy: jest.SpyInstance
+  let warnSpy: jest.SpyInstance
+  let errorSpy: jest.SpyInstance
+
+  beforeEach(() => {
+    process.env.NODE_ENV = 'development'
+    logSpy = jest.spyOn(console, 'log').mockImplementation(() => {})
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+    errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    logSpy.mockRestore()
+    warnSpy.mockRestore()
+    errorSpy.mockRestore()
+    process.env.NODE_ENV = originalNodeEnv
+  })
+
+  it('routes log messages to console.log', () => {
+    logger.log('hello')
+
+    expect(logSpy).toHaveBeenCalledTimes(1)
+    expect(warnSpy).not.toHaveBeenCalled()
+    expect(errorSpy).not.toHaveBeenCalled()
+  })
+
+  it('routes warn messages to console.warn', () => {
+    logger.warn('watch out')
+
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    expect(logSpy).not.toHaveBeenCalled()
+    expect(errorSpy).not.toHaveBeenCalled()
+  })
+
+  it('routes error messages to console.error', () => {
+    logger.error('boom')
+
+    expect(errorSpy).toHaveBeenCalledTimes(1)
+    expect(logSpy).not.toHaveBeenCalled()
+    expect(warnSpy).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- fix direct encoded-path navigation returning 500 by replacing `src/utils/logger.ts` with an SSR-safe local logger implementation
- preserve logger API (`log`, `warn`, `error`) and production no-op semantics
- remove `logbench` end-to-end and route levels to native console methods (`console.log`, `console.warn`, `console.error`)
- add logger tests validating level routing (`log`/`warn`/`error`) so regression is caught automatically
- isolate logger env tests using `jest.resetModules()` + dynamic import so `NODE_ENV` setup is real (not dead code)

## Reproduction (before fix)
- requesting `GET /https%3A%2F%2Fgithub.com%2FSirajChokshi%2FDelineatedTheme` returned `HTTP/1.1 500 Internal Server Error`
- Vite SSR trace showed `TypeError: ... default is not a function` originating from `src/utils/logger.ts`

## Root cause
- `logbench` default import interop fails on the SSR path in this runtime; importing `Preview` for direct route rendering pulls in `logger.ts` and throws before page render

## Fix details
- remove `logbench` dependency usage from `src/utils/logger.ts`
- remove `logbench` from `package.json`/`package-lock.json`
- keep logger API while mapping levels correctly:
  - `log` -> `console.log`
  - `warn` -> `console.warn`
  - `error` -> `console.error`
- keep styled `%c` output and production no-op behavior
- resolve console method at call-time so runtime hooks/spies and devtools filtering behave correctly
- rewrite logger tests to isolate module/env state per test via `jest.resetModules()` and `await import()`
- add explicit production no-op test coverage

## Validation
- route returns `HTTP/1.1 200 OK` for the same direct encoded path
- logger routing tests pass (`tests/logger.test.ts`)
- lint, full tests, type-check, and build all pass
- manual browser verification in incognito confirms direct path URL loads with no 500 page

## Walkthrough artifacts
<a href="https://cursor.com/agents/bc-b92f6409-a41c-4318-b978-fc222231637c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdirect_path_url_after_logger_cleanup_demo.mp4"><img src="https://cursor.com/artifacts/c/art-244f5dfa-53c5-4143-84c9-3a916114dd3d" alt="direct_path_url_after_logger_cleanup_demo.mp4" /></a>
![Direct encoded path URL after logger cleanup](https://cursor.com/artifacts/c/art-a7c6f39d-806a-4c5a-b6d9-43f2e4d5621e)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b92f6409-a41c-4318-b978-fc222231637c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b92f6409-a41c-4318-b978-fc222231637c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

