### PR TITLE
chore: fix dev server port and add Node.js version note in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@
 | Task         | Command                                           |
 | ------------ | ------------------------------------------------- |
 | Install deps | `npm install`                                     |
-| Dev server   | `npm run dev` (serves on `http://localhost:3000`) |
+| Dev server   | `npm run dev` (serves on `http://localhost:5173`) |
 | Lint         | `npm run lint` (prettier + eslint)                |
 | Tests        | `npm run test` (Jest — URL parsing only)          |
 | Build        | `npm run build`                                   |
@@ -18,7 +18,8 @@
 ### Notes
 
 - The `prepare` script (`svelte-kit sync`) runs automatically during `npm install`. If you see import errors for `$app/*` modules, re-run `npm install`.
-- The dev server uses port **3000** by default. Pass `--host 0.0.0.0` to expose it outside localhost: `npm run dev -- --host 0.0.0.0`.
+- The dev server uses Vite's default port **5173**. Pass `--host 0.0.0.0` to expose it outside localhost: `npm run dev -- --host 0.0.0.0`.
+- Requires **Node.js >= 24** (`engines` field in `package.json`). Use `nvm use 24` if multiple versions are installed.
 - Preview functionality depends on the external CORS proxy `api.codetabs.com`. If previews fail to load, this third-party service may be down.
 - `svelte-preprocess` deprecation warnings about "defaults" are expected and harmless.
 - The `package-lock.json` uses npm; do not mix with other package managers.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Corrects inaccurate dev server port in `AGENTS.md` (was 3000, actual Vite default is 5173) and adds a note about the Node.js >= 24 requirement.

### Changes
- Fixed dev server port reference from `localhost:3000` to `localhost:5173`
- Added note about Node.js >= 24 requirement from `package.json` engines field

### Environment Verification

All checks pass on the development environment:

| Check | Status |
|-------|--------|
| `npm run lint` | Passes (prettier + eslint) |
| `npm run test` | 22/22 tests pass |
| `npm run build` | Builds successfully |
| `npm run check` | 0 errors, 0 warnings |
| `npm run dev` | Serves on port 5173 |

### Demo

<a href="https://cursor.com/agents/bc-e8bd9386-dacd-43c9-9f7d-a8ef23c57f85/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstatic_preview_demo.mp4"><img src="https://cursor.com/artifacts/c/art-01485b27-ce09-4835-9957-6d3f69e88134" alt="static_preview_demo.mp4" /></a>

![Homepage loaded successfully](https://cursor.com/artifacts/c/art-58177436-4f7a-435f-a157-bf1d7d98516d)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e8bd9386-dacd-43c9-9f7d-a8ef23c57f85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e8bd9386-dacd-43c9-9f7d-a8ef23c57f85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

