### PR TITLE
Proxy origins fallback

### DIFF
--- a/src/utils/proxy.ts
+++ b/src/utils/proxy.ts
@@ -120,14 +120,14 @@ export function getAllowedProxyOrigins(
   configuredOrigins: string | undefined,
   requestOrigin: string,
 ): string[] {
-  const allowedOrigins = configuredOrigins
-    ?.split(',')
-    .map((origin) => origin.trim())
-    .filter(Boolean)
-    .map((origin) => normalizeOrigin(origin))
-    .filter((origin): origin is string => Boolean(origin))
+  if (configuredOrigins !== undefined) {
+    const allowedOrigins = configuredOrigins
+      .split(',')
+      .map((origin) => origin.trim())
+      .filter(Boolean)
+      .map((origin) => normalizeOrigin(origin))
+      .filter((origin): origin is string => Boolean(origin))
 
-  if (allowedOrigins && allowedOrigins.length > 0) {
     return [...new Set(allowedOrigins)]
   }
 


### PR DESCRIPTION
Prevent `getAllowedProxyOrigins` from silently falling back to default permissive origins when `PROXY_ALLOWED_ORIGINS` is explicitly set with invalid values.

Previously, if `PROXY_ALLOWED_ORIGINS` was set but contained only invalid entries (e.g., missing `https://`), the system would silently fall back to the default allowed origins, including `http://localhost:5173`. This created a security vulnerability where an operator intending to restrict access would unknowingly configure a more permissive proxy than intended. The fix ensures that if `PROXY_ALLOWED_ORIGINS` is explicitly provided, only valid entries are considered, even if that results in an empty list.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes proxy/CORS allowlist behavior: a misconfigured `PROXY_ALLOWED_ORIGINS` now yields an empty allowlist (blocking requests) instead of falling back to permissive defaults, which may impact existing deployments relying on the previous fallback.
> 
> **Overview**
> Tightens proxy CORS allowlist handling by treating `PROXY_ALLOWED_ORIGINS` as authoritative whenever it is set.
> 
> If the env var is provided but parses to no valid origins, `getAllowedProxyOrigins` now returns an empty list rather than falling back to `DEFAULT_ALLOWED_ORIGINS` plus the current `requestOrigin`, preventing unintended permissive access (e.g., `http://localhost:5173`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22d9a116f67430ebe805f93cc2494c06e04cb95a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->