### PR TITLE
Fix complex website preview loading and broken asset resolution

### DIFF
--- a/src/components/Preview.svelte
+++ b/src/components/Preview.svelte
@@ -9,26 +9,49 @@
 
   let loading = true
   let preview: Preview | undefined = undefined
+  let renderNonce = 0
 
   let title = ''
 
   $: {
     if (url) {
       const decodedUrl = decodeURIComponent(url)
+      const currentRender = ++renderNonce
 
       if (typeof window !== 'undefined') {
         if (!preview) {
           preview = new Preview('#site-frame')
         }
 
-        preview.render(decodedUrl).then(() => {
-          loading = false
+        loading = true
+        title = ''
 
-          if (preview?.pageData.title) {
-            // update with page title or URL
-            title = preview.pageData.title
-          }
-        })
+        preview
+          .render(decodedUrl)
+          .then(() => {
+            if (currentRender !== renderNonce) {
+              return
+            }
+
+            if (preview?.pageData.title) {
+              // update with page title or URL
+              title = preview.pageData.title
+            }
+          })
+          .catch(() => {
+            if (currentRender !== renderNonce) {
+              return
+            }
+
+            title = decodedUrl
+          })
+          .finally(() => {
+            if (currentRender !== renderNonce) {
+              return
+            }
+
+            loading = false
+          })
       }
     }
   }

--- a/src/routes/api/proxy/+server.ts
+++ b/src/routes/api/proxy/+server.ts
@@ -1,4 +1,5 @@
 import { error } from '@sveltejs/kit'
+import { appendFileSync } from 'node:fs'
 import {
   buildCorsHeaders,
   getAllowedProxyOrigins,
@@ -12,6 +13,28 @@ import {
 } from '../../../utils/proxy'
 
 export const prerender = false
+
+function writeDebugLog(
+  hypothesisId: string,
+  location: string,
+  message: string,
+  data: Record<string, unknown>,
+) {
+  try {
+    appendFileSync(
+      '/opt/cursor/logs/debug.log',
+      `${JSON.stringify({
+        hypothesisId,
+        location,
+        message,
+        data,
+        timestamp: Date.now(),
+      })}\n`,
+    )
+  } catch {
+    // Best-effort instrumentation only.
+  }
+}
 
 function enforceProxyPolicy(request: Request, requestUrl: URL) {
   const allowedOrigins = getAllowedProxyOrigins(
@@ -39,6 +62,15 @@ export function OPTIONS({ request, url }) {
 export async function GET({ request, url, fetch }) {
   const corsHeaders = enforceProxyPolicy(request, url)
 
+  // #region agent log
+  writeDebugLog('A', 'src/routes/api/proxy/+server.ts:69', 'Proxy GET entry', {
+    urlParam: url.searchParams.get('url'),
+    secFetchDest: request.headers.get('sec-fetch-dest'),
+    requestOrigin:
+      request.headers.get('origin') ?? request.headers.get('referer'),
+  })
+  // #endregion
+
   if (isNavigationProxyRequest(request.headers.get('sec-fetch-dest'))) {
     throw error(403, 'Direct navigation to proxy endpoint is not allowed')
   }
@@ -49,11 +81,37 @@ export async function GET({ request, url, fetch }) {
     target = parseProxyTarget(url.searchParams.get('url'))
   } catch (err) {
     if (err instanceof ProxyRequestError) {
+      // #region agent log
+      writeDebugLog(
+        'A',
+        'src/routes/api/proxy/+server.ts:85',
+        'Proxy target rejected by policy',
+        {
+          urlParam: url.searchParams.get('url'),
+          status: err.status,
+          reason: err.message,
+        },
+      )
+      // #endregion
+
       throw error(err.status, err.message)
     }
 
     throw error(400, 'Invalid url param')
   }
+
+  // #region agent log
+  writeDebugLog(
+    'C',
+    'src/routes/api/proxy/+server.ts:102',
+    'Proxy target accepted',
+    {
+      target: target.toString(),
+      hostname: target.hostname,
+      pathname: target.pathname,
+    },
+  )
+  // #endregion
 
   let upstream: Response
 
@@ -65,8 +123,33 @@ export async function GET({ request, url, fetch }) {
       },
     })
   } catch {
+    // #region agent log
+    writeDebugLog(
+      'D',
+      'src/routes/api/proxy/+server.ts:125',
+      'Upstream fetch threw network error',
+      {
+        target: target.toString(),
+      },
+    )
+    // #endregion
+
     throw error(502, `Could not load ${target.toString()}`)
   }
+
+  // #region agent log
+  writeDebugLog(
+    'C',
+    'src/routes/api/proxy/+server.ts:138',
+    'Upstream fetch returned response',
+    {
+      target: target.toString(),
+      status: upstream.status,
+      contentType: upstream.headers.get('content-type'),
+      contentLength: upstream.headers.get('content-length'),
+    },
+  )
+  // #endregion
 
   const contentLength = Number(upstream.headers.get('content-length'))
   if (
@@ -107,6 +190,19 @@ export async function GET({ request, url, fetch }) {
   if (lastModified) {
     headers.set('Last-Modified', lastModified)
   }
+
+  // #region agent log
+  writeDebugLog(
+    'C',
+    'src/routes/api/proxy/+server.ts:190',
+    'Proxy returning payload',
+    {
+      target: target.toString(),
+      status: upstream.status,
+      payloadBytes: payload.byteLength,
+    },
+  )
+  // #endregion
 
   return new Response(payload, {
     status: upstream.status,

--- a/src/routes/api/proxy/+server.ts
+++ b/src/routes/api/proxy/+server.ts
@@ -1,5 +1,4 @@
 import { error } from '@sveltejs/kit'
-import { appendFileSync } from 'node:fs'
 import {
   buildCorsHeaders,
   getAllowedProxyOrigins,
@@ -13,28 +12,6 @@ import {
 } from '../../../utils/proxy'
 
 export const prerender = false
-
-function writeDebugLog(
-  hypothesisId: string,
-  location: string,
-  message: string,
-  data: Record<string, unknown>,
-) {
-  try {
-    appendFileSync(
-      '/opt/cursor/logs/debug.log',
-      `${JSON.stringify({
-        hypothesisId,
-        location,
-        message,
-        data,
-        timestamp: Date.now(),
-      })}\n`,
-    )
-  } catch {
-    // Best-effort instrumentation only.
-  }
-}
 
 function enforceProxyPolicy(request: Request, requestUrl: URL) {
   const allowedOrigins = getAllowedProxyOrigins(
@@ -62,15 +39,6 @@ export function OPTIONS({ request, url }) {
 export async function GET({ request, url, fetch }) {
   const corsHeaders = enforceProxyPolicy(request, url)
 
-  // #region agent log
-  writeDebugLog('A', 'src/routes/api/proxy/+server.ts:69', 'Proxy GET entry', {
-    urlParam: url.searchParams.get('url'),
-    secFetchDest: request.headers.get('sec-fetch-dest'),
-    requestOrigin:
-      request.headers.get('origin') ?? request.headers.get('referer'),
-  })
-  // #endregion
-
   if (isNavigationProxyRequest(request.headers.get('sec-fetch-dest'))) {
     throw error(403, 'Direct navigation to proxy endpoint is not allowed')
   }
@@ -81,37 +49,11 @@ export async function GET({ request, url, fetch }) {
     target = parseProxyTarget(url.searchParams.get('url'))
   } catch (err) {
     if (err instanceof ProxyRequestError) {
-      // #region agent log
-      writeDebugLog(
-        'A',
-        'src/routes/api/proxy/+server.ts:85',
-        'Proxy target rejected by policy',
-        {
-          urlParam: url.searchParams.get('url'),
-          status: err.status,
-          reason: err.message,
-        },
-      )
-      // #endregion
-
       throw error(err.status, err.message)
     }
 
     throw error(400, 'Invalid url param')
   }
-
-  // #region agent log
-  writeDebugLog(
-    'C',
-    'src/routes/api/proxy/+server.ts:102',
-    'Proxy target accepted',
-    {
-      target: target.toString(),
-      hostname: target.hostname,
-      pathname: target.pathname,
-    },
-  )
-  // #endregion
 
   let upstream: Response
 
@@ -123,33 +65,8 @@ export async function GET({ request, url, fetch }) {
       },
     })
   } catch {
-    // #region agent log
-    writeDebugLog(
-      'D',
-      'src/routes/api/proxy/+server.ts:125',
-      'Upstream fetch threw network error',
-      {
-        target: target.toString(),
-      },
-    )
-    // #endregion
-
     throw error(502, `Could not load ${target.toString()}`)
   }
-
-  // #region agent log
-  writeDebugLog(
-    'C',
-    'src/routes/api/proxy/+server.ts:138',
-    'Upstream fetch returned response',
-    {
-      target: target.toString(),
-      status: upstream.status,
-      contentType: upstream.headers.get('content-type'),
-      contentLength: upstream.headers.get('content-length'),
-    },
-  )
-  // #endregion
 
   const contentLength = Number(upstream.headers.get('content-length'))
   if (
@@ -190,19 +107,6 @@ export async function GET({ request, url, fetch }) {
   if (lastModified) {
     headers.set('Last-Modified', lastModified)
   }
-
-  // #region agent log
-  writeDebugLog(
-    'C',
-    'src/routes/api/proxy/+server.ts:190',
-    'Proxy returning payload',
-    {
-      target: target.toString(),
-      status: upstream.status,
-      payloadBytes: payload.byteLength,
-    },
-  )
-  // #endregion
 
   return new Response(payload, {
     status: upstream.status,

--- a/src/routes/img/[...path]/+server.ts
+++ b/src/routes/img/[...path]/+server.ts
@@ -1,0 +1,67 @@
+import { error } from '@sveltejs/kit'
+import {
+  buildImageFallbackTargets,
+  decodePreviewUrlFromReferer,
+  isSupportedImageFallbackSource,
+  sanitizeRelativePath,
+} from '../../../utils/image-fallback'
+
+export const prerender = false
+
+export async function GET({ request, params, fetch }) {
+  const imagePath = sanitizeRelativePath(params.path)
+  if (!imagePath) {
+    throw error(400, 'Invalid image path')
+  }
+
+  const previewUrl = decodePreviewUrlFromReferer(request.headers.get('referer'))
+  if (!previewUrl) {
+    throw error(404, 'Preview context unavailable')
+  }
+
+  if (!isSupportedImageFallbackSource(previewUrl)) {
+    throw error(404, 'Preview source not supported for image fallback')
+  }
+
+  const targets = buildImageFallbackTargets(previewUrl, imagePath)
+  if (!targets.length) {
+    throw error(404, 'Could not resolve image target')
+  }
+
+  for (const target of targets) {
+    let upstream: Response
+    try {
+      upstream = await fetch(target, {
+        redirect: 'follow',
+        headers: {
+          Accept: request.headers.get('accept') ?? 'image/*,*/*',
+        },
+      })
+    } catch {
+      continue
+    }
+
+    if (!upstream.ok) {
+      continue
+    }
+
+    const payload = await upstream.arrayBuffer()
+    const headers = new Headers()
+
+    const contentType = upstream.headers.get('content-type')
+    if (contentType) {
+      headers.set('Content-Type', contentType)
+    }
+    headers.set(
+      'Cache-Control',
+      upstream.headers.get('cache-control') ?? 'public, max-age=300',
+    )
+
+    return new Response(payload, {
+      status: upstream.status,
+      headers,
+    })
+  }
+
+  throw error(404, 'Image not found')
+}

--- a/src/utils/image-fallback.ts
+++ b/src/utils/image-fallback.ts
@@ -1,28 +1,6 @@
 import { resourceType } from '../types/resources'
+import { getRepositoryRoot } from './lang/html'
 import { getResourceType, isValidURL, processUrl } from './url'
-
-function getRepositoryRoot(rawHtmlUrl: URL): string | undefined {
-  const segments = rawHtmlUrl.pathname.split('/').filter(Boolean)
-
-  if (
-    rawHtmlUrl.hostname === 'raw.githubusercontent.com' &&
-    segments.length >= 3
-  ) {
-    const [owner, repo, branch] = segments
-    return `https://${rawHtmlUrl.hostname}/${owner}/${repo}/${branch}/`
-  }
-
-  const rawMarker = segments.findIndex(
-    (segment, idx) => segment === '-' && segments[idx + 1] === 'raw',
-  )
-  if (rawHtmlUrl.hostname === 'gitlab.com' && rawMarker >= 2) {
-    return `https://${rawHtmlUrl.hostname}/${segments
-      .slice(0, rawMarker + 3)
-      .join('/')}/`
-  }
-
-  return undefined
-}
 
 export function sanitizeRelativePath(
   pathParam: string | undefined,

--- a/src/utils/image-fallback.ts
+++ b/src/utils/image-fallback.ts
@@ -1,0 +1,120 @@
+import { resourceType } from '../types/resources'
+import { getResourceType, isValidURL, processUrl } from './url'
+
+function getRepositoryRoot(rawHtmlUrl: URL): string | undefined {
+  const segments = rawHtmlUrl.pathname.split('/').filter(Boolean)
+
+  if (
+    rawHtmlUrl.hostname === 'raw.githubusercontent.com' &&
+    segments.length >= 3
+  ) {
+    const [owner, repo, branch] = segments
+    return `https://${rawHtmlUrl.hostname}/${owner}/${repo}/${branch}/`
+  }
+
+  const rawMarker = segments.findIndex(
+    (segment, idx) => segment === '-' && segments[idx + 1] === 'raw',
+  )
+  if (rawHtmlUrl.hostname === 'gitlab.com' && rawMarker >= 2) {
+    return `https://${rawHtmlUrl.hostname}/${segments
+      .slice(0, rawMarker + 3)
+      .join('/')}/`
+  }
+
+  return undefined
+}
+
+export function sanitizeRelativePath(
+  pathParam: string | undefined,
+): string | undefined {
+  if (!pathParam) {
+    return undefined
+  }
+
+  let decodedPath: string
+  try {
+    decodedPath = decodeURIComponent(pathParam)
+  } catch {
+    return undefined
+  }
+
+  const segments = decodedPath.split('/').filter(Boolean)
+  if (!segments.length) {
+    return undefined
+  }
+
+  if (segments.some((segment) => segment === '.' || segment === '..')) {
+    return undefined
+  }
+
+  return segments.join('/')
+}
+
+export function decodePreviewUrlFromReferer(
+  refererHeader: string | null,
+): string | undefined {
+  if (!refererHeader) {
+    return undefined
+  }
+
+  let refererUrl: URL
+  try {
+    refererUrl = new URL(refererHeader)
+  } catch {
+    return undefined
+  }
+
+  const queryUrl = refererUrl.searchParams.get('url')
+  if (queryUrl && isValidURL(queryUrl)) {
+    return queryUrl
+  }
+
+  const slug = refererUrl.pathname.replace(/^\/+/, '')
+  if (!slug) {
+    return undefined
+  }
+
+  try {
+    const decodedSlug = decodeURIComponent(slug)
+    if (isValidURL(decodedSlug)) {
+      return decodedSlug
+    }
+  } catch {
+    return undefined
+  }
+
+  return undefined
+}
+
+export function buildImageFallbackTargets(
+  previewUrl: string,
+  imagePath: string,
+): string[] {
+  const htmlCandidates = processUrl(previewUrl)
+  const targets: string[] = []
+
+  htmlCandidates.forEach((candidate) => {
+    let candidateUrl: URL
+    try {
+      candidateUrl = new URL(candidate)
+    } catch {
+      return
+    }
+
+    const repositoryRoot = getRepositoryRoot(candidateUrl)
+    if (!repositoryRoot) {
+      return
+    }
+
+    targets.push(new URL(`img/${imagePath}`, repositoryRoot).toString())
+  })
+
+  return [...new Set(targets)]
+}
+
+export function isSupportedImageFallbackSource(previewUrl: string): boolean {
+  const previewType = getResourceType(previewUrl, false)
+  return (
+    previewType === resourceType.GITHUB || previewType === resourceType.GITLAB
+  )
+}

--- a/src/utils/lang/html.ts
+++ b/src/utils/lang/html.ts
@@ -88,7 +88,7 @@ function serializeDoctype(doc: Document): string {
 
 function rewriteRootRelativeAttributes(doc: Document) {
   const rootRelativeAttributes = ['src', 'href'] as const
-  const $assets = doc.querySelectorAll<HTMLElement>('[src], [href], [content]')
+  const $assets = doc.querySelectorAll<HTMLElement>('[src], [href]')
 
   for (const $asset of $assets) {
     for (const attr of rootRelativeAttributes) {
@@ -124,7 +124,7 @@ function isAbsoluteOrSpecialUrl(value: string): boolean {
 
 function rewriteRelativeResourceAttributes(doc: Document, pageUrl: URL) {
   const urlAttributes = ['src', 'href'] as const
-  const $assets = doc.querySelectorAll<HTMLElement>('[src], [href], [content]')
+  const $assets = doc.querySelectorAll<HTMLElement>('[src], [href]')
 
   for (const $asset of $assets) {
     const tagName = $asset.tagName.toLowerCase()
@@ -210,7 +210,7 @@ function rewriteRootRelativeToRepo(doc: Document, rawPageUrl: URL) {
   const repositoryRoot = getRepositoryRoot(rawPageUrl)
 
   const rootRelativeAttributes = ['src', 'href'] as const
-  const $assets = doc.querySelectorAll<HTMLElement>('[src], [href], [content]')
+  const $assets = doc.querySelectorAll<HTMLElement>('[src], [href]')
 
   for (const $asset of $assets) {
     const tagName = $asset.tagName.toLowerCase()

--- a/src/utils/lang/html.ts
+++ b/src/utils/lang/html.ts
@@ -4,12 +4,226 @@ export function isHTML(maybeHTML: string): boolean {
   return [...$div.childNodes].reverse().some(($child) => $child.nodeType === 1)
 }
 
+export const PREVIEW_SCRIPT_PLACEHOLDER_TYPE =
+  'application/static-preview-script'
+export const PREVIEW_SCRIPT_SRC_ATTRIBUTE = 'data-preview-script-src'
+export const PREVIEW_SCRIPT_TYPE_ATTRIBUTE = 'data-preview-script-type'
+
 function getTitle(html: string) {
   // TODO: Regex might reasonably be faster here
   const $div = document.createElement('div')
   $div.innerHTML = html
   const $title = $div.querySelector('title')
   return $title?.textContent ?? undefined
+}
+
+function serializeDoctype(doc: Document): string {
+  const { doctype } = doc
+  if (!doctype) {
+    return ''
+  }
+
+  let serialized = `<!DOCTYPE ${doctype.name}`
+
+  if (doctype.publicId) {
+    serialized += ` PUBLIC "${doctype.publicId}"`
+  } else if (doctype.systemId) {
+    serialized += ' SYSTEM'
+  }
+
+  if (doctype.systemId) {
+    serialized += ` "${doctype.systemId}"`
+  }
+
+  serialized += '>'
+  return serialized
+}
+
+function rewriteRootRelativeAttributes(doc: Document) {
+  const rootRelativeAttributes = ['src', 'href'] as const
+  const $assets = doc.querySelectorAll<HTMLElement>('[src], [href], [content]')
+
+  for (const $asset of $assets) {
+    for (const attr of rootRelativeAttributes) {
+      const value = $asset.getAttribute(attr)
+      if (!value) {
+        continue
+      }
+
+      // Keep protocol-relative URLs (`//cdn.example.com`) untouched.
+      if (!value.startsWith('/') || value.startsWith('//')) {
+        continue
+      }
+
+      $asset.setAttribute(attr, value.slice(1))
+    }
+  }
+}
+
+function isAbsoluteOrSpecialUrl(value: string): boolean {
+  const normalized = value.trim().toLowerCase()
+
+  return (
+    normalized.startsWith('http://') ||
+    normalized.startsWith('https://') ||
+    normalized.startsWith('//') ||
+    normalized.startsWith('data:') ||
+    normalized.startsWith('mailto:') ||
+    normalized.startsWith('tel:') ||
+    normalized.startsWith('javascript:') ||
+    normalized.startsWith('#')
+  )
+}
+
+function rewriteRelativeResourceAttributes(doc: Document, pageUrl: URL) {
+  const urlAttributes = ['src', 'href'] as const
+  const $assets = doc.querySelectorAll<HTMLElement>('[src], [href], [content]')
+
+  for (const $asset of $assets) {
+    const tagName = $asset.tagName.toLowerCase()
+
+    for (const attr of urlAttributes) {
+      const value = $asset.getAttribute(attr)
+      if (!value) {
+        continue
+      }
+
+      // Preserve navigation links and already-absolute values.
+      if (
+        (attr === 'href' && (tagName === 'a' || tagName === 'area')) ||
+        isAbsoluteOrSpecialUrl(value) ||
+        value.startsWith('/')
+      ) {
+        continue
+      }
+
+      try {
+        $asset.setAttribute(attr, new URL(value, pageUrl).toString())
+      } catch {
+        // Keep original attribute when URL parsing fails.
+      }
+    }
+  }
+}
+
+function normalizePathname(pathname: string): string {
+  const segments = pathname.split('/')
+  const normalized: string[] = []
+
+  for (const segment of segments) {
+    if (!segment || segment === '.') {
+      continue
+    }
+
+    if (segment === '..') {
+      normalized.pop()
+      continue
+    }
+
+    normalized.push(segment)
+  }
+
+  return `/${normalized.join('/')}`
+}
+
+function getRepositoryRoot(url: URL): string {
+  const pathname = normalizePathname(url.pathname)
+  const segments = pathname.split('/').filter(Boolean)
+
+  if (url.hostname === 'raw.githubusercontent.com' && segments.length >= 3) {
+    const [owner, repo, branch] = segments
+    return `https://${url.hostname}/${owner}/${repo}/${branch}/`
+  }
+
+  const rawMarker = segments.findIndex(
+    (segment, idx) => segment === '-' && segments[idx + 1] === 'raw',
+  )
+  if (url.hostname === 'gitlab.com' && rawMarker >= 2) {
+    return `https://${url.hostname}/${segments
+      .slice(0, rawMarker + 3)
+      .join('/')}/`
+  }
+
+  return new URL('.', url).toString()
+}
+
+function rewriteRootRelativeToRepo(doc: Document, rawPageUrl: URL) {
+  const baseHref = doc.head.querySelector('base')?.getAttribute('href')
+  if (!baseHref) {
+    return
+  }
+
+  let pageBaseUrl: URL
+  try {
+    pageBaseUrl = new URL(baseHref)
+  } catch {
+    return
+  }
+
+  const repositoryRoot = getRepositoryRoot(rawPageUrl)
+
+  const rootRelativeAttributes = ['src', 'href'] as const
+  const $assets = doc.querySelectorAll<HTMLElement>('[src], [href], [content]')
+
+  for (const $asset of $assets) {
+    const tagName = $asset.tagName.toLowerCase()
+    const keepRootRelativeOnSameOrigin =
+      tagName === 'a' ||
+      tagName === 'area' ||
+      tagName === 'form' ||
+      tagName === 'base'
+
+    for (const attr of rootRelativeAttributes) {
+      const value = $asset.getAttribute(attr)
+      if (!value || !value.startsWith('/')) {
+        continue
+      }
+
+      // Keep protocol-relative URLs untouched.
+      if (value.startsWith('//')) {
+        continue
+      }
+
+      const resolvedUrl = new URL(value, pageBaseUrl)
+      if (
+        resolvedUrl.origin === pageBaseUrl.origin &&
+        keepRootRelativeOnSameOrigin
+      ) {
+        continue
+      }
+
+      $asset.setAttribute(
+        attr,
+        new URL(value.slice(1), repositoryRoot).toString(),
+      )
+    }
+  }
+}
+
+function deferScriptExecution(doc: Document) {
+  const $scripts = doc.querySelectorAll<HTMLScriptElement>('script')
+
+  for (const $script of $scripts) {
+    const src = $script.getAttribute('src')
+    if (src) {
+      let resolvedSrc = src
+      try {
+        resolvedSrc = new URL(src, doc.baseURI).toString()
+      } catch {
+        // Keep the original script source when URL parsing fails.
+      }
+
+      $script.setAttribute(PREVIEW_SCRIPT_SRC_ATTRIBUTE, resolvedSrc)
+      $script.removeAttribute('src')
+    }
+
+    const type = $script.getAttribute('type')
+    if (type) {
+      $script.setAttribute(PREVIEW_SCRIPT_TYPE_ATTRIBUTE, type)
+    }
+
+    $script.setAttribute('type', PREVIEW_SCRIPT_PLACEHOLDER_TYPE)
+  }
 }
 
 export interface HTMLPageData {
@@ -22,11 +236,23 @@ export interface HTMLPageData {
 }
 
 export function processHTML(html: string, url: string): HTMLPageData {
-  const processedHTML = html
-    // Add base tag to iframe
-    .replace(/<head([^>]*)>/i, `<head$1><base href="${url}">`)
-    // Replace absolute paths with relative paths
-    .replace(/((src|href|content)=")\/(.*?")/gm, '$1$3')
+  const parser = new DOMParser()
+  const doc = parser.parseFromString(html, 'text/html')
+  const pageUrl = new URL(url)
+
+  if (!doc.head.querySelector('base')) {
+    const base = doc.createElement('base')
+    base.setAttribute('href', url)
+    doc.head.prepend(base)
+  }
+
+  rewriteRootRelativeToRepo(doc, pageUrl)
+  rewriteRootRelativeAttributes(doc)
+  rewriteRelativeResourceAttributes(doc, pageUrl)
+  deferScriptExecution(doc)
+
+  const doctype = serializeDoctype(doc)
+  const processedHTML = `${doctype}${doctype ? '\n' : ''}${doc.documentElement.outerHTML}`
 
   return {
     processedHTML,

--- a/src/utils/lang/html.ts
+++ b/src/utils/lang/html.ts
@@ -126,7 +126,7 @@ function normalizePathname(pathname: string): string {
   return `/${normalized.join('/')}`
 }
 
-function getRepositoryRoot(url: URL): string {
+export function getRepositoryRoot(url: URL): string {
   const pathname = normalizePathname(url.pathname)
   const segments = pathname.split('/').filter(Boolean)
 

--- a/src/utils/preview.ts
+++ b/src/utils/preview.ts
@@ -2,7 +2,14 @@ import { goto } from '$app/navigation'
 import { PreviewError, errorType } from './errors'
 import { proxyFetch } from './fetch'
 import { processCSS } from './lang/css'
-import { isHTML, processHTML, type HTMLPageData } from './lang/html'
+import {
+  isHTML,
+  PREVIEW_SCRIPT_PLACEHOLDER_TYPE,
+  PREVIEW_SCRIPT_SRC_ATTRIBUTE,
+  PREVIEW_SCRIPT_TYPE_ATTRIBUTE,
+  processHTML,
+  type HTMLPageData,
+} from './lang/html'
 import logger from './logger'
 import { processUrl } from './url'
 
@@ -12,6 +19,7 @@ export class Preview {
 
   // Session
   resources: Record<string, string> = {}
+  currentPageUrl: URL | undefined
 
   // TODO - might be worth memoizing against the URL for the session
   pageData: Partial<HTMLPageData> = {}
@@ -85,6 +93,7 @@ export class Preview {
     }
 
     const { processedHTML, title } = processHTML(data, url)
+    this.currentPageUrl = new URL(url)
 
     this.pageData.title = title ?? url
 
@@ -102,15 +111,28 @@ export class Preview {
       this.iframeDocument.document.addEventListener('click', (e) => {
         const $el = e.target as HTMLElement
         const $anchor = $el.closest<HTMLAnchorElement>('a')
+        const href = $anchor?.getAttribute('href')
 
-        if ($anchor) {
-          e.preventDefault()
-
-          // TODO: Check if it's a relative link
-
-          // use Svelte navigation to trigger a re-render from the top of the UI
-          goto(`/${encodeURIComponent($anchor.href)}`)
+        if (!$anchor || !href || href.startsWith('#')) {
+          return
         }
+
+        let resolvedUrl: URL
+        try {
+          resolvedUrl = new URL(href, this.iframeDocument.location.href)
+        } catch {
+          return
+        }
+
+        // Keep external links inside the iframe navigation flow.
+        if (!this.isProxySupportedUrl(resolvedUrl.toString())) {
+          return
+        }
+
+        e.preventDefault()
+
+        // use Svelte navigation to trigger a re-render from the top of the UI
+        goto(`/${encodeURIComponent(resolvedUrl.toString())}`)
       })
     })
   }
@@ -145,36 +167,42 @@ export class Preview {
     })
 
     // Load page JS
+    const scriptSelector = `script[src], script[type="${PREVIEW_SCRIPT_PLACEHOLDER_TYPE}"]`
     const $script =
       this.iframeDocument.document.querySelectorAll<HTMLScriptElement>(
-        'script[src]',
+        scriptSelector,
       )
 
-    const scripts = [...$script]
-      .filter(({ src }) => this.shouldProxyScript(src))
-      .map(async (script) => {
-        const payload = await this.load(script.src)
-        const scriptType = script.getAttribute('type')?.toLowerCase().trim()
+    for (const script of [...$script]) {
+      const source =
+        script.getAttribute(PREVIEW_SCRIPT_SRC_ATTRIBUTE) ?? script.src ?? ''
+      const scriptType =
+        script
+          .getAttribute(PREVIEW_SCRIPT_TYPE_ATTRIBUTE)
+          ?.toLowerCase()
+          .trim() ?? script.getAttribute('type')?.toLowerCase().trim()
+      const type = scriptType === 'module' ? ('module' as const) : undefined
+      const inlinePayload = script.textContent ?? ''
 
-        // Prevent the browser from trying to load unsupported raw URLs directly.
-        script.remove()
+      script.remove()
 
-        return {
-          payload,
-          type: scriptType === 'module' ? ('module' as const) : undefined,
+      if (source) {
+        if (this.shouldProxyScript(source)) {
+          try {
+            const payload = await this.load(source)
+            this.appendScriptToHead(payload, type)
+          } catch (err) {
+            logger.warn(`Skipping script after failed fetch: ${err}`)
+          }
+          continue
         }
-      })
 
-    const scriptResults = await Promise.allSettled(scripts)
-    scriptResults.forEach((result) => {
-      if (result.status !== 'fulfilled') {
-        logger.warn(`Skipping script after failed fetch: ${result.reason}`)
-        return
+        await this.appendExternalScriptToHead(source, type)
+        continue
       }
 
-      const { payload, type } = result.value
-      this.appendScriptToHead(payload, type)
-    })
+      this.appendScriptToHead(inlinePayload, type)
+    }
 
     this.iframeDocument.document.dispatchEvent(
       new Event('DOMContentLoaded', { bubbles: true, cancelable: true }),
@@ -231,6 +259,20 @@ export class Preview {
     }
 
     tag.textContent = data
+    this.iframeDocument.document.head.appendChild(tag)
+  }
+
+  private async appendExternalScriptToHead(
+    src: string,
+    type?: 'module',
+  ): Promise<void> {
+    const tag = this.iframeDocument.document.createElement('script')
+
+    if (type) {
+      tag.type = type
+    }
+
+    tag.src = src
     this.iframeDocument.document.head.appendChild(tag)
   }
 

--- a/src/utils/preview.ts
+++ b/src/utils/preview.ts
@@ -117,7 +117,10 @@ export class Preview {
 
         let resolvedUrl: URL
         try {
-          resolvedUrl = new URL(href, this.iframeDocument.location.href)
+          const resolutionBase =
+            this.iframeDocument.document.baseURI ||
+            this.iframeDocument.location.href
+          resolvedUrl = new URL(href, resolutionBase)
         } catch {
           return
         }

--- a/src/utils/preview.ts
+++ b/src/utils/preview.ts
@@ -124,19 +124,27 @@ export class Preview {
       this.iframeDocument.document.querySelectorAll<HTMLLinkElement>(
         'link[rel=stylesheet]',
       )
-    const links = [...$link].map(async ({ href }: { href: string }) => {
-      const payload = await this.load(`${href}`)
-      return {
-        url: href,
-        payload,
-      }
-    })
-
-    await Promise.all(links).then((res) => {
-      res.forEach(({ payload, url: cssUrl }) => {
-        const processedCSS = processCSS(payload, cssUrl)
-        this.appendToHead(processedCSS, 'style')
+    const links = [...$link]
+      .map(({ href }) => href)
+      .filter((href) => this.shouldProxyStylesheet(href))
+      .map(async (href) => {
+        const payload = await this.load(href)
+        return {
+          url: href,
+          payload,
+        }
       })
+
+    const stylesheetResults = await Promise.allSettled(links)
+    stylesheetResults.forEach((result) => {
+      if (result.status !== 'fulfilled') {
+        logger.warn(`Skipping stylesheet after failed fetch: ${result.reason}`)
+        return
+      }
+
+      const { payload, url: cssUrl } = result.value
+      const processedCSS = processCSS(payload, cssUrl)
+      this.appendToHead(processedCSS, 'style')
     })
 
     // Load page JS
@@ -160,21 +168,39 @@ export class Preview {
         }
       })
 
-    await Promise.all(scripts).then((res) => {
-      res.forEach(({ payload, type }) => this.appendScriptToHead(payload, type))
+    const scriptResults = await Promise.allSettled(scripts)
+    scriptResults.forEach((result) => {
+      if (result.status !== 'fulfilled') {
+        logger.warn(`Skipping script after failed fetch: ${result.reason}`)
+        return
+      }
 
-      this.iframeDocument.document.dispatchEvent(
-        new Event('DOMContentLoaded', { bubbles: true, cancelable: true }),
-      ) // Dispatch DOMContentLoaded event after loading all scripts
+      const { payload, type } = result.value
+      this.appendScriptToHead(payload, type)
     })
+
+    this.iframeDocument.document.dispatchEvent(
+      new Event('DOMContentLoaded', { bubbles: true, cancelable: true }),
+    ) // Dispatch DOMContentLoaded event after loading all scripts
+  }
+
+  /**
+   * Determine whether a script source should be fetched via proxy.
+   */
+  private shouldProxyStylesheet(href: string): boolean {
+    return this.isProxySupportedUrl(href)
   }
 
   /**
    * Determine whether a script source should be fetched via proxy.
    */
   private shouldProxyScript(src: string): boolean {
+    return this.isProxySupportedUrl(src)
+  }
+
+  private isProxySupportedUrl(url: string): boolean {
     return (
-      src.includes('//raw.githubusercontent.com') || src.includes('/-/raw/')
+      url.includes('//raw.githubusercontent.com') || url.includes('/-/raw/')
     )
   }
 

--- a/src/utils/preview.ts
+++ b/src/utils/preview.ts
@@ -195,7 +195,11 @@ export class Preview {
           continue
         }
 
-        await this.appendExternalScriptToHead(source, type)
+        try {
+          await this.appendExternalScriptToHead(source, type)
+        } catch (err) {
+          logger.warn(`Skipping script after failed external load: ${err}`)
+        }
         continue
       }
 

--- a/src/utils/preview.ts
+++ b/src/utils/preview.ts
@@ -175,11 +175,12 @@ export class Preview {
       const source =
         script.getAttribute(PREVIEW_SCRIPT_SRC_ATTRIBUTE) ?? script.src ?? ''
       const scriptType =
-        script
-          .getAttribute(PREVIEW_SCRIPT_TYPE_ATTRIBUTE)
-          ?.toLowerCase()
-          .trim() ?? script.getAttribute('type')?.toLowerCase().trim()
-      const type = scriptType === 'module' ? ('module' as const) : undefined
+        script.getAttribute(PREVIEW_SCRIPT_TYPE_ATTRIBUTE)?.trim() ??
+        script.getAttribute('type')?.trim()
+      const type =
+        scriptType && scriptType !== PREVIEW_SCRIPT_PLACEHOLDER_TYPE
+          ? scriptType
+          : undefined
       const inlinePayload = script.textContent ?? ''
 
       script.remove()
@@ -249,7 +250,7 @@ export class Preview {
   /**
    * Inline JS into the preview head.
    */
-  private appendScriptToHead(data: string, type?: 'module'): void {
+  private appendScriptToHead(data: string, type?: string): void {
     if (!data) {
       return
     }
@@ -266,7 +267,7 @@ export class Preview {
 
   private appendExternalScriptToHead(
     src: string,
-    type?: 'module',
+    type?: string,
   ): Promise<void> {
     return new Promise<void>((resolve, reject) => {
       const tag = this.iframeDocument.document.createElement('script')

--- a/src/utils/preview.ts
+++ b/src/utils/preview.ts
@@ -19,7 +19,6 @@ export class Preview {
 
   // Session
   resources: Record<string, string> = {}
-  currentPageUrl: URL | undefined
 
   // TODO - might be worth memoizing against the URL for the session
   pageData: Partial<HTMLPageData> = {}
@@ -93,7 +92,6 @@ export class Preview {
     }
 
     const { processedHTML, title } = processHTML(data, url)
-    this.currentPageUrl = new URL(url)
 
     this.pageData.title = title ?? url
 
@@ -262,18 +260,22 @@ export class Preview {
     this.iframeDocument.document.head.appendChild(tag)
   }
 
-  private async appendExternalScriptToHead(
+  private appendExternalScriptToHead(
     src: string,
     type?: 'module',
   ): Promise<void> {
-    const tag = this.iframeDocument.document.createElement('script')
+    return new Promise<void>((resolve, reject) => {
+      const tag = this.iframeDocument.document.createElement('script')
 
-    if (type) {
-      tag.type = type
-    }
+      if (type) {
+        tag.type = type
+      }
 
-    tag.src = src
-    this.iframeDocument.document.head.appendChild(tag)
+      tag.onload = () => resolve()
+      tag.onerror = () => reject(new Error(`Failed to load script: ${src}`))
+      tag.src = src
+      this.iframeDocument.document.head.appendChild(tag)
+    })
   }
 
   /**

--- a/src/utils/preview.ts
+++ b/src/utils/preview.ts
@@ -41,18 +41,15 @@ export class Preview {
       // if the URL is an HTML file, we can just load it
       const htmlURL = urls[0]
 
-      this.load(htmlURL)
-        .then(async (data) => {
-          await this.loadHTML(data, htmlURL)
-        })
-        .catch(() => {
-          throw new PreviewError(
-            `Could not find any valid HTML files. Tried:\n${urls.join(
-              '\n - ',
-            )}`,
-            errorType.NOT_FOUND,
-          )
-        })
+      try {
+        const data = await this.load(htmlURL)
+        await this.loadHTML(data, htmlURL)
+      } catch {
+        throw new PreviewError(
+          `Could not find any valid HTML files. Tried:\n${urls.join('\n - ')}`,
+          errorType.NOT_FOUND,
+        )
+      }
     } else {
       // otherwise we have to attempt to load 3 possible URLs
       const errorTable = new Array(urls.length).fill(false)

--- a/tests/image-fallback.test.ts
+++ b/tests/image-fallback.test.ts
@@ -7,23 +7,23 @@ import {
 describe('[Image fallback route]', () => {
   it('extracts preview URL from encoded referer path', () => {
     const referer =
-      'http://localhost:5173/https%3A%2F%2Fgithub.com%2FOpenEmu%2Fopenemu.github.io'
+      'http://localhost:5173/https%3A%2F%2Fgithub.invalid%2Fexample-owner%2Fexample-static-site'
 
     expect(decodePreviewUrlFromReferer(referer)).toBe(
-      'https://github.com/OpenEmu/openemu.github.io',
+      'https://github.invalid/example-owner/example-static-site',
     )
   })
 
   it('builds deduplicated raw targets for github repositories', () => {
     const targets = buildImageFallbackTargets(
-      'https://github.com/OpenEmu/openemu.github.io',
+      'https://github.invalid/example-owner/example-static-site',
       'logo.png',
     )
 
     expect(targets).toEqual(
       expect.arrayContaining([
-        'https://raw.githubusercontent.com/OpenEmu/openemu.github.io/master/img/logo.png',
-        'https://raw.githubusercontent.com/OpenEmu/openemu.github.io/main/img/logo.png',
+        'https://raw.githubusercontent.com/example-owner/example-static-site/master/img/logo.png',
+        'https://raw.githubusercontent.com/example-owner/example-static-site/main/img/logo.png',
       ]),
     )
   })
@@ -39,12 +39,12 @@ describe('[Image fallback route]', () => {
 
   it('resolves first candidate before fallback branch candidate', () => {
     const targets = buildImageFallbackTargets(
-      'https://github.com/OpenEmu/openemu.github.io',
+      'https://github.invalid/example-owner/example-static-site',
       'logo.png',
     )
 
     expect(targets[0]).toBe(
-      'https://raw.githubusercontent.com/OpenEmu/openemu.github.io/master/img/logo.png',
+      'https://raw.githubusercontent.com/example-owner/example-static-site/master/img/logo.png',
     )
   })
 })

--- a/tests/image-fallback.test.ts
+++ b/tests/image-fallback.test.ts
@@ -1,0 +1,50 @@
+import {
+  buildImageFallbackTargets,
+  decodePreviewUrlFromReferer,
+  sanitizeRelativePath,
+} from '../src/utils/image-fallback'
+
+describe('[Image fallback route]', () => {
+  it('extracts preview URL from encoded referer path', () => {
+    const referer =
+      'http://localhost:5173/https%3A%2F%2Fgithub.com%2FOpenEmu%2Fopenemu.github.io'
+
+    expect(decodePreviewUrlFromReferer(referer)).toBe(
+      'https://github.com/OpenEmu/openemu.github.io',
+    )
+  })
+
+  it('builds deduplicated raw targets for github repositories', () => {
+    const targets = buildImageFallbackTargets(
+      'https://github.com/OpenEmu/openemu.github.io',
+      'logo.png',
+    )
+
+    expect(targets).toEqual(
+      expect.arrayContaining([
+        'https://raw.githubusercontent.com/OpenEmu/openemu.github.io/master/img/logo.png',
+        'https://raw.githubusercontent.com/OpenEmu/openemu.github.io/main/img/logo.png',
+      ]),
+    )
+  })
+
+  it('sanitizes image fallback paths', () => {
+    expect(sanitizeRelativePath('logo.png')).toBe('logo.png')
+    expect(sanitizeRelativePath('nested/path/logo.png')).toBe(
+      'nested/path/logo.png',
+    )
+    expect(sanitizeRelativePath('../logo.png')).toBeUndefined()
+    expect(sanitizeRelativePath('./logo.png')).toBeUndefined()
+  })
+
+  it('resolves first candidate before fallback branch candidate', () => {
+    const targets = buildImageFallbackTargets(
+      'https://github.com/OpenEmu/openemu.github.io',
+      'logo.png',
+    )
+
+    expect(targets[0]).toBe(
+      'https://raw.githubusercontent.com/OpenEmu/openemu.github.io/master/img/logo.png',
+    )
+  })
+})

--- a/tests/preview.test.ts
+++ b/tests/preview.test.ts
@@ -2,6 +2,8 @@ jest.mock('$app/navigation', () => ({ goto: jest.fn() }), { virtual: true })
 
 import { Preview } from '../src/utils/preview'
 
+const originalWarn = console.warn
+
 function mockResponse(status: number, body: string): Response {
   return {
     status,
@@ -28,19 +30,23 @@ function getProxyTarget(input: string | URL | Request): string {
 describe('[Preview] resource loading resilience', () => {
   let originalFetch: typeof fetch | undefined
 
+  const htmlUrl =
+    'https://raw.githubusercontent.com/OpenEmu/openemu.github.io/master/index.html'
+  const proxiedCssUrl =
+    'https://raw.githubusercontent.com/OpenEmu/openemu.github.io/master/styles/site.css'
+
   beforeEach(() => {
     document.body.innerHTML = '<iframe id="site-frame"></iframe>'
     originalFetch = global.fetch
+    console.warn = jest.fn()
   })
 
   afterEach(() => {
     global.fetch = originalFetch as typeof fetch
+    console.warn = originalWarn
   })
 
   it('skips proxy for non-allowlisted external stylesheet URLs', async () => {
-    const htmlUrl =
-      'https://raw.githubusercontent.com/OpenEmu/openemu.github.io/master/index.html'
-
     const htmlPayload = `
       <!doctype html>
       <html>
@@ -58,6 +64,10 @@ describe('[Preview] resource loading resilience', () => {
 
       if (target === htmlUrl) {
         return mockResponse(200, htmlPayload)
+      }
+
+      if (target === proxiedCssUrl) {
+        return mockResponse(200, 'body { color: #111; }')
       }
 
       throw new Error(`Unexpected proxy target requested: ${target}`)
@@ -78,11 +88,10 @@ describe('[Preview] resource loading resilience', () => {
         target.includes('fonts.googleapis.com'),
       ),
     ).toBe(false)
+    expect(requestedTargets).toContain(proxiedCssUrl)
   })
 
   it('continues rendering when a proxied stylesheet fetch fails', async () => {
-    const htmlUrl =
-      'https://raw.githubusercontent.com/OpenEmu/openemu.github.io/master/index.html'
     const failingCssUrl =
       'https://raw.githubusercontent.com/OpenEmu/openemu.github.io/master/styles/failing.css'
 
@@ -118,9 +127,6 @@ describe('[Preview] resource loading resilience', () => {
   })
 
   it('awaits single-url rendering before resolving', async () => {
-    const htmlUrl =
-      'https://raw.githubusercontent.com/OpenEmu/openemu.github.io/master/index.html'
-
     const htmlPayload = `
       <!doctype html>
       <html>
@@ -161,5 +167,184 @@ describe('[Preview] resource loading resilience', () => {
 
     resolveFetch?.(mockResponse(200, htmlPayload))
     await expect(renderPromise).resolves.toBeUndefined()
+  })
+
+  it('rewrites root-relative and hash links to remain in the proxied repo', async () => {
+    const htmlPayload = `
+      <!doctype html>
+      <html>
+        <head>
+          <title>OpenEmu</title>
+        </head>
+        <body>
+          <a id="root-link" href="/files/press-pack-v2.zip">Press Pack</a>
+          <a id="hash-link" href="#overview">Overview</a>
+          <a id="relative-link" href="img/logo.png">Logo</a>
+        </body>
+      </html>
+    `
+
+    const fetchMock = jest.fn(async (input: string | URL | Request) => {
+      const target = getProxyTarget(input)
+
+      if (target === htmlUrl) {
+        return mockResponse(200, htmlPayload)
+      }
+
+      throw new Error(`Unexpected proxy target requested: ${target}`)
+    })
+
+    global.fetch = fetchMock as unknown as typeof fetch
+
+    const preview = new Preview('#site-frame')
+    await expect(preview.render(htmlUrl)).resolves.toBeUndefined()
+
+    const doc =
+      document.querySelector<HTMLIFrameElement>('#site-frame')?.contentDocument
+    expect(doc).toBeTruthy()
+
+    const rootLink = doc?.querySelector<HTMLAnchorElement>('#root-link')
+    const hashLink = doc?.querySelector<HTMLAnchorElement>('#hash-link')
+    const relativeLink = doc?.querySelector<HTMLAnchorElement>('#relative-link')
+
+    expect(rootLink?.getAttribute('href')).toBe('files/press-pack-v2.zip')
+    expect(hashLink?.getAttribute('href')).toBe('#overview')
+    expect(relativeLink?.getAttribute('href')).toBe('img/logo.png')
+  })
+
+  it('rewrites media and stylesheet URLs to absolute raw repo URLs', async () => {
+    const expectedImageUrl =
+      'https://raw.githubusercontent.com/OpenEmu/openemu.github.io/master/img/logo.png'
+    const expectedStylesheetUrl =
+      'https://raw.githubusercontent.com/OpenEmu/openemu.github.io/master/styles/site.css'
+
+    const htmlPayload = `
+      <!doctype html>
+      <html>
+        <head>
+          <title>OpenEmu</title>
+          <link id="repo-css" rel="stylesheet" href="styles/site.css" />
+        </head>
+        <body>
+          <img id="hero" src="img/logo.png" />
+        </body>
+      </html>
+    `
+
+    const fetchMock = jest.fn(async (input: string | URL | Request) => {
+      const target = getProxyTarget(input)
+
+      if (target === htmlUrl) {
+        return mockResponse(200, htmlPayload)
+      }
+
+      if (target === expectedStylesheetUrl) {
+        return mockResponse(200, 'body { color: #111; }')
+      }
+
+      throw new Error(`Unexpected proxy target requested: ${target}`)
+    })
+
+    global.fetch = fetchMock as unknown as typeof fetch
+
+    const preview = new Preview('#site-frame')
+    await expect(preview.render(htmlUrl)).resolves.toBeUndefined()
+
+    const doc =
+      document.querySelector<HTMLIFrameElement>('#site-frame')?.contentDocument
+    expect(doc).toBeTruthy()
+
+    const hero = doc?.querySelector<HTMLImageElement>('#hero')
+    const css = doc?.querySelector<HTMLLinkElement>('#repo-css')
+
+    expect(hero?.getAttribute('src')).toBe(expectedImageUrl)
+    expect(css?.getAttribute('href')).toBe(expectedStylesheetUrl)
+  })
+
+  it('executes deferred scripts in order', async () => {
+    const libraryScriptUrl =
+      'https://raw.githubusercontent.com/OpenEmu/openemu.github.io/master/js/lib.js'
+
+    const htmlPayload = `
+      <!doctype html>
+      <html>
+        <head>
+          <title>OpenEmu</title>
+          <script src="./js/lib.js"></script>
+          <script>
+            document.body.setAttribute(
+              'data-lib-loaded',
+              window.__libReady ? 'yes' : 'no',
+            )
+          </script>
+        </head>
+        <body><h1>Site</h1></body>
+      </html>
+    `
+
+    const fetchMock = jest.fn(async (input: string | URL | Request) => {
+      const target = getProxyTarget(input)
+
+      if (target === htmlUrl) {
+        return mockResponse(200, htmlPayload)
+      }
+
+      if (target === libraryScriptUrl) {
+        return mockResponse(200, 'window.__libReady = true;')
+      }
+
+      throw new Error(`Unexpected proxy target requested: ${target}`)
+    })
+
+    global.fetch = fetchMock as unknown as typeof fetch
+
+    const preview = new Preview('#site-frame')
+    await expect(preview.render(htmlUrl)).resolves.toBeUndefined()
+
+    const doc =
+      document.querySelector<HTMLIFrameElement>('#site-frame')?.contentDocument
+    expect(doc?.body.getAttribute('data-lib-loaded')).toBe('yes')
+  })
+
+  it('preserves script order for proxied and inline scripts', async () => {
+    const proxiedScriptUrl =
+      'https://raw.githubusercontent.com/OpenEmu/openemu.github.io/master/js/a.js'
+
+    const htmlPayload = `
+      <!doctype html>
+      <html>
+        <head>
+          <title>OpenEmu</title>
+          <script src="./js/a.js"></script>
+          <script>
+            document.body.setAttribute('data-inline-order', window.__scriptOrder || 'missing')
+          </script>
+        </head>
+        <body><h1>Site</h1></body>
+      </html>
+    `
+
+    const fetchMock = jest.fn(async (input: string | URL | Request) => {
+      const target = getProxyTarget(input)
+
+      if (target === htmlUrl) {
+        return mockResponse(200, htmlPayload)
+      }
+
+      if (target === proxiedScriptUrl) {
+        return mockResponse(200, 'window.__scriptOrder = "proxied-first";')
+      }
+
+      throw new Error(`Unexpected proxy target requested: ${target}`)
+    })
+
+    global.fetch = fetchMock as unknown as typeof fetch
+
+    const preview = new Preview('#site-frame')
+    await expect(preview.render(htmlUrl)).resolves.toBeUndefined()
+
+    const doc =
+      document.querySelector<HTMLIFrameElement>('#site-frame')?.contentDocument
+    expect(doc?.body.getAttribute('data-inline-order')).toBe('proxied-first')
   })
 })

--- a/tests/preview.test.ts
+++ b/tests/preview.test.ts
@@ -1,8 +1,10 @@
 jest.mock('$app/navigation', () => ({ goto: jest.fn() }), { virtual: true })
 
+import { goto } from '$app/navigation'
 import { Preview } from '../src/utils/preview'
 
 const originalWarn = console.warn
+const gotoMock = goto as jest.MockedFunction<typeof goto>
 
 function mockResponse(status: number, body: string): Response {
   return {
@@ -39,6 +41,7 @@ describe('[Preview] resource loading resilience', () => {
     document.body.innerHTML = '<iframe id="site-frame"></iframe>'
     originalFetch = global.fetch
     console.warn = jest.fn()
+    gotoMock.mockClear()
   })
 
   afterEach(() => {
@@ -248,6 +251,56 @@ describe('[Preview] resource loading resilience', () => {
 
     resolveFetch?.(mockResponse(200, htmlPayload))
     await expect(renderPromise).resolves.toBeUndefined()
+  })
+
+  it('resolves relative anchor clicks against base URI for in-preview navigation', async () => {
+    const expectedNavigationTarget =
+      'https://raw.githubusercontent.com/example-owner/example-static-site/master/docs/setup.html'
+    const htmlPayload = `
+      <!doctype html>
+      <html>
+        <head>
+          <title>Demo Site</title>
+        </head>
+        <body>
+          <a id="relative-nav" href="docs/setup.html">Setup Guide</a>
+        </body>
+      </html>
+    `
+
+    const fetchMock = jest.fn(async (input: string | URL | Request) => {
+      const target = getProxyTarget(input)
+
+      if (target === htmlUrl) {
+        return mockResponse(200, htmlPayload)
+      }
+
+      throw new Error(`Unexpected proxy target requested: ${target}`)
+    })
+
+    global.fetch = fetchMock as unknown as typeof fetch
+
+    const preview = new Preview('#site-frame')
+    await expect(preview.render(htmlUrl)).resolves.toBeUndefined()
+
+    const iframe = document.querySelector<HTMLIFrameElement>('#site-frame')
+    expect(iframe).toBeTruthy()
+    iframe?.dispatchEvent(new Event('load'))
+
+    const relativeLink =
+      iframe?.contentDocument?.querySelector<HTMLAnchorElement>('#relative-nav')
+    expect(relativeLink).toBeTruthy()
+
+    const clickEvent = new MouseEvent('click', {
+      bubbles: true,
+      cancelable: true,
+    })
+    const clickHandled = relativeLink?.dispatchEvent(clickEvent)
+
+    expect(clickHandled).toBe(false)
+    expect(gotoMock).toHaveBeenCalledWith(
+      `/${encodeURIComponent(expectedNavigationTarget)}`,
+    )
   })
 
   it('rewrites root-relative and hash links to remain in the proxied repo', async () => {

--- a/tests/preview.test.ts
+++ b/tests/preview.test.ts
@@ -124,6 +124,51 @@ describe('[Preview] resource loading resilience', () => {
     await expect(preview.render(htmlUrl)).resolves.toBeUndefined()
   })
 
+  it('continues rendering when a non-proxied external script fails', async () => {
+    const htmlPayload = `
+      <!doctype html>
+      <html>
+        <head>
+          <title>Demo Site</title>
+          <script src="https://cdn.invalid/app.js"></script>
+        </head>
+        <body><h1>Site</h1></body>
+      </html>
+    `
+
+    const fetchMock = jest.fn(async (input: string | URL | Request) => {
+      const target = getProxyTarget(input)
+
+      if (target === htmlUrl) {
+        return mockResponse(200, htmlPayload)
+      }
+
+      throw new Error(`Unexpected proxy target requested: ${target}`)
+    })
+
+    global.fetch = fetchMock as unknown as typeof fetch
+
+    const preview = new Preview('#site-frame')
+    const externalScriptSpy = jest
+      .spyOn(
+        preview as unknown as {
+          appendExternalScriptToHead: (
+            src: string,
+            type?: 'module',
+          ) => Promise<void>
+        },
+        'appendExternalScriptToHead',
+      )
+      .mockRejectedValue(new Error('external script load failure'))
+
+    await expect(preview.render(htmlUrl)).resolves.toBeUndefined()
+
+    expect(externalScriptSpy).toHaveBeenCalledWith(
+      'https://cdn.invalid/app.js',
+      undefined,
+    )
+  })
+
   it('awaits single-url rendering before resolving', async () => {
     const htmlPayload = `
       <!doctype html>

--- a/tests/preview.test.ts
+++ b/tests/preview.test.ts
@@ -154,7 +154,7 @@ describe('[Preview] resource loading resilience', () => {
         preview as unknown as {
           appendExternalScriptToHead: (
             src: string,
-            type?: 'module',
+            type?: string,
           ) => Promise<void>
         },
         'appendExternalScriptToHead',
@@ -167,6 +167,44 @@ describe('[Preview] resource loading resilience', () => {
       'https://cdn.invalid/app.js',
       undefined,
     )
+  })
+
+  it('preserves non-module script types during deferred replay', async () => {
+    const htmlPayload = `
+      <!doctype html>
+      <html>
+        <head>
+          <title>Demo Site</title>
+          <script type="application/ld+json">
+            {"@context":"https://schema.org","name":"Demo"}
+          </script>
+        </head>
+        <body><h1>Site</h1></body>
+      </html>
+    `
+
+    const fetchMock = jest.fn(async (input: string | URL | Request) => {
+      const target = getProxyTarget(input)
+
+      if (target === htmlUrl) {
+        return mockResponse(200, htmlPayload)
+      }
+
+      throw new Error(`Unexpected proxy target requested: ${target}`)
+    })
+
+    global.fetch = fetchMock as unknown as typeof fetch
+
+    const preview = new Preview('#site-frame')
+    await expect(preview.render(htmlUrl)).resolves.toBeUndefined()
+
+    const doc =
+      document.querySelector<HTMLIFrameElement>('#site-frame')?.contentDocument
+    const scriptTypes = [...(doc?.querySelectorAll('script') ?? [])].map(
+      (script) => script.getAttribute('type'),
+    )
+
+    expect(scriptTypes).toContain('application/ld+json')
   })
 
   it('awaits single-url rendering before resolving', async () => {

--- a/tests/preview.test.ts
+++ b/tests/preview.test.ts
@@ -1,0 +1,119 @@
+jest.mock('$app/navigation', () => ({ goto: jest.fn() }), { virtual: true })
+
+import { Preview } from '../src/utils/preview'
+
+function mockResponse(status: number, body: string): Response {
+  return {
+    status,
+    ok: status >= 200 && status < 300,
+    text: async () => body,
+  } as unknown as Response
+}
+
+function getProxyTarget(input: string | URL | Request): string {
+  if (typeof input === 'string') {
+    return new URL(input, 'http://localhost').searchParams.get('url') ?? ''
+  }
+
+  if (input instanceof URL) {
+    return (
+      new URL(input.toString(), 'http://localhost').searchParams.get('url') ??
+      ''
+    )
+  }
+
+  return new URL(input.url, 'http://localhost').searchParams.get('url') ?? ''
+}
+
+describe('[Preview] resource loading resilience', () => {
+  let originalFetch: typeof fetch | undefined
+
+  beforeEach(() => {
+    document.body.innerHTML = '<iframe id="site-frame"></iframe>'
+    originalFetch = global.fetch
+  })
+
+  afterEach(() => {
+    global.fetch = originalFetch as typeof fetch
+  })
+
+  it('skips proxy for non-allowlisted external stylesheet URLs', async () => {
+    const htmlUrl =
+      'https://raw.githubusercontent.com/OpenEmu/openemu.github.io/master/index.html'
+
+    const htmlPayload = `
+      <!doctype html>
+      <html>
+        <head>
+          <title>OpenEmu</title>
+          <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@100;400;700&display=swap" />
+          <link rel="stylesheet" href="styles/site.css" />
+        </head>
+        <body><h1>Site</h1></body>
+      </html>
+    `
+
+    const fetchMock = jest.fn(async (input: string | URL | Request) => {
+      const target = getProxyTarget(input)
+
+      if (target === htmlUrl) {
+        return mockResponse(200, htmlPayload)
+      }
+
+      throw new Error(`Unexpected proxy target requested: ${target}`)
+    })
+
+    global.fetch = fetchMock as unknown as typeof fetch
+
+    const preview = new Preview('#site-frame')
+    await expect(preview.render(htmlUrl)).resolves.toBeUndefined()
+
+    const requestedTargets = fetchMock.mock.calls.map(([input]) =>
+      getProxyTarget(input as string | URL | Request),
+    )
+
+    expect(requestedTargets).toContain(htmlUrl)
+    expect(
+      requestedTargets.some((target) =>
+        target.includes('fonts.googleapis.com'),
+      ),
+    ).toBe(false)
+  })
+
+  it('continues rendering when a proxied stylesheet fetch fails', async () => {
+    const htmlUrl =
+      'https://raw.githubusercontent.com/OpenEmu/openemu.github.io/master/index.html'
+    const failingCssUrl =
+      'https://raw.githubusercontent.com/OpenEmu/openemu.github.io/master/styles/failing.css'
+
+    const htmlPayload = `
+      <!doctype html>
+      <html>
+        <head>
+          <title>OpenEmu</title>
+          <link rel="stylesheet" href="styles/failing.css" />
+        </head>
+        <body><h1>Site</h1></body>
+      </html>
+    `
+
+    const fetchMock = jest.fn(async (input: string | URL | Request) => {
+      const target = getProxyTarget(input)
+
+      if (target === htmlUrl) {
+        return mockResponse(200, htmlPayload)
+      }
+
+      if (target === failingCssUrl) {
+        return mockResponse(403, '{"message":"Target url is not allowed"}')
+      }
+
+      throw new Error(`Unexpected proxy target requested: ${target}`)
+    })
+
+    global.fetch = fetchMock as unknown as typeof fetch
+
+    const preview = new Preview('#site-frame')
+    await expect(preview.render(htmlUrl)).resolves.toBeUndefined()
+  })
+})

--- a/tests/preview.test.ts
+++ b/tests/preview.test.ts
@@ -31,9 +31,9 @@ describe('[Preview] resource loading resilience', () => {
   let originalFetch: typeof fetch | undefined
 
   const htmlUrl =
-    'https://raw.githubusercontent.com/OpenEmu/openemu.github.io/master/index.html'
+    'https://raw.githubusercontent.com/example-owner/example-static-site/master/index.html'
   const proxiedCssUrl =
-    'https://raw.githubusercontent.com/OpenEmu/openemu.github.io/master/styles/site.css'
+    'https://raw.githubusercontent.com/example-owner/example-static-site/master/styles/site.css'
 
   beforeEach(() => {
     document.body.innerHTML = '<iframe id="site-frame"></iframe>'
@@ -51,8 +51,8 @@ describe('[Preview] resource loading resilience', () => {
       <!doctype html>
       <html>
         <head>
-          <title>OpenEmu</title>
-          <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@100;400;700&display=swap" />
+          <title>Demo Site</title>
+          <link rel="stylesheet" href="https://cdn.invalid/css/demo.css" />
           <link rel="stylesheet" href="styles/site.css" />
         </head>
         <body><h1>Site</h1></body>
@@ -84,22 +84,20 @@ describe('[Preview] resource loading resilience', () => {
 
     expect(requestedTargets).toContain(htmlUrl)
     expect(
-      requestedTargets.some((target) =>
-        target.includes('fonts.googleapis.com'),
-      ),
+      requestedTargets.some((target) => target.includes('cdn.invalid')),
     ).toBe(false)
     expect(requestedTargets).toContain(proxiedCssUrl)
   })
 
   it('continues rendering when a proxied stylesheet fetch fails', async () => {
     const failingCssUrl =
-      'https://raw.githubusercontent.com/OpenEmu/openemu.github.io/master/styles/failing.css'
+      'https://raw.githubusercontent.com/example-owner/example-static-site/master/styles/failing.css'
 
     const htmlPayload = `
       <!doctype html>
       <html>
         <head>
-          <title>OpenEmu</title>
+          <title>Demo Site</title>
           <link rel="stylesheet" href="styles/failing.css" />
         </head>
         <body><h1>Site</h1></body>
@@ -131,7 +129,7 @@ describe('[Preview] resource loading resilience', () => {
       <!doctype html>
       <html>
         <head>
-          <title>Delayed OpenEmu</title>
+          <title>Delayed Demo Site</title>
         </head>
         <body><h1>Site</h1></body>
       </html>
@@ -174,7 +172,7 @@ describe('[Preview] resource loading resilience', () => {
       <!doctype html>
       <html>
         <head>
-          <title>OpenEmu</title>
+          <title>Demo Site</title>
         </head>
         <body>
           <a id="root-link" href="/files/press-pack-v2.zip">Press Pack</a>
@@ -214,15 +212,15 @@ describe('[Preview] resource loading resilience', () => {
 
   it('rewrites media and stylesheet URLs to absolute raw repo URLs', async () => {
     const expectedImageUrl =
-      'https://raw.githubusercontent.com/OpenEmu/openemu.github.io/master/img/logo.png'
+      'https://raw.githubusercontent.com/example-owner/example-static-site/master/img/logo.png'
     const expectedStylesheetUrl =
-      'https://raw.githubusercontent.com/OpenEmu/openemu.github.io/master/styles/site.css'
+      'https://raw.githubusercontent.com/example-owner/example-static-site/master/styles/site.css'
 
     const htmlPayload = `
       <!doctype html>
       <html>
         <head>
-          <title>OpenEmu</title>
+          <title>Demo Site</title>
           <link id="repo-css" rel="stylesheet" href="styles/site.css" />
         </head>
         <body>
@@ -263,13 +261,13 @@ describe('[Preview] resource loading resilience', () => {
 
   it('executes deferred scripts in order', async () => {
     const libraryScriptUrl =
-      'https://raw.githubusercontent.com/OpenEmu/openemu.github.io/master/js/lib.js'
+      'https://raw.githubusercontent.com/example-owner/example-static-site/master/js/lib.js'
 
     const htmlPayload = `
       <!doctype html>
       <html>
         <head>
-          <title>OpenEmu</title>
+          <title>Demo Site</title>
           <script src="./js/lib.js"></script>
           <script>
             document.body.setAttribute(
@@ -308,13 +306,13 @@ describe('[Preview] resource loading resilience', () => {
 
   it('preserves script order for proxied and inline scripts', async () => {
     const proxiedScriptUrl =
-      'https://raw.githubusercontent.com/OpenEmu/openemu.github.io/master/js/a.js'
+      'https://raw.githubusercontent.com/example-owner/example-static-site/master/js/a.js'
 
     const htmlPayload = `
       <!doctype html>
       <html>
         <head>
-          <title>OpenEmu</title>
+          <title>Demo Site</title>
           <script src="./js/a.js"></script>
           <script>
             document.body.setAttribute('data-inline-order', window.__scriptOrder || 'missing')

--- a/tests/preview.test.ts
+++ b/tests/preview.test.ts
@@ -116,4 +116,50 @@ describe('[Preview] resource loading resilience', () => {
     const preview = new Preview('#site-frame')
     await expect(preview.render(htmlUrl)).resolves.toBeUndefined()
   })
+
+  it('awaits single-url rendering before resolving', async () => {
+    const htmlUrl =
+      'https://raw.githubusercontent.com/OpenEmu/openemu.github.io/master/index.html'
+
+    const htmlPayload = `
+      <!doctype html>
+      <html>
+        <head>
+          <title>Delayed OpenEmu</title>
+        </head>
+        <body><h1>Site</h1></body>
+      </html>
+    `
+
+    let resolveFetch:
+      | ((value: Response | PromiseLike<Response>) => void)
+      | undefined
+
+    const fetchMock = jest.fn(async (input: string | URL | Request) => {
+      const target = getProxyTarget(input)
+
+      if (target === htmlUrl) {
+        return await new Promise<Response>((resolve) => {
+          resolveFetch = resolve
+        })
+      }
+
+      throw new Error(`Unexpected proxy target requested: ${target}`)
+    })
+
+    global.fetch = fetchMock as unknown as typeof fetch
+
+    const preview = new Preview('#site-frame')
+    const renderPromise = preview.render(htmlUrl)
+    let isSettled = false
+    void renderPromise.then(() => {
+      isSettled = true
+    })
+
+    await Promise.resolve()
+    expect(isSettled).toBe(false)
+
+    resolveFetch?.(mockResponse(200, htmlPayload))
+    await expect(renderPromise).resolves.toBeUndefined()
+  })
 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Merge latest `origin/main` into this branch and resolve `src/utils/lang/html.ts` conflicts by combining both intents safely.
- Keep the DOMParser-based rewrite/deferred-script pipeline from this branch.
- Integrate `main`’s runtime fetch-resolver support by injecting the resolver script into processed HTML before deferred script handling.
- Add `tests/html.test.ts` from `main`, adapted to synthetic fixture URLs and to assert merged behavior (resolver injection + rewrite semantics).

## Conflict classification and resolution
- **Simple conflict (resolved):** top-level additions in `html.ts` were non-overlapping (`PREVIEW_SCRIPT_*` constants vs `getFetchResolverScript()` helper), so both were kept.
- **Complicated conflict (resolved with intent merge):** `processHTML()` had conflicting implementations (DOMParser pipeline vs regex/string replacement). Resolved by preserving DOMParser architecture and integrating resolver injection as an additive step.

## Testing
- `npm run test -- tests/html.test.ts tests/preview.test.ts tests/image-fallback.test.ts tests/proxy.test.ts`
- `npm run lint`
- `npm run check`

## Walkthrough
<a href="https://cursor.com/agents/bc-93bd68fb-e6af-4b97-b433-faab48f56a23/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fopenemu_preview_playwright_full_flow.webm"><img src="https://cursor.com/artifacts/c/art-33836043-7d39-49ec-b776-f8d3280668d0" alt="openemu_preview_playwright_full_flow.webm" /></a>

![OpenEmu preview rendered with hero content](https://cursor.com/artifacts/c/art-bd512e67-6dc6-40cf-8366-ce0ff188acc9)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-93bd68fb-e6af-4b97-b433-faab48f56a23"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-93bd68fb-e6af-4b97-b433-faab48f56a23"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

