### PR TITLE
Preview script and utilities

### DIFF
--- a/src/utils/image-fallback.ts
+++ b/src/utils/image-fallback.ts
@@ -1,28 +1,6 @@
 import { resourceType } from '../types/resources'
+import { getRepositoryRoot } from './lang/html'
 import { getResourceType, isValidURL, processUrl } from './url'
-
-function getRepositoryRoot(rawHtmlUrl: URL): string | undefined {
-  const segments = rawHtmlUrl.pathname.split('/').filter(Boolean)
-
-  if (
-    rawHtmlUrl.hostname === 'raw.githubusercontent.com' &&
-    segments.length >= 3
-  ) {
-    const [owner, repo, branch] = segments
-    return `https://${rawHtmlUrl.hostname}/${owner}/${repo}/${branch}/`
-  }
-
-  const rawMarker = segments.findIndex(
-    (segment, idx) => segment === '-' && segments[idx + 1] === 'raw',
-  )
-  if (rawHtmlUrl.hostname === 'gitlab.com' && rawMarker >= 2) {
-    return `https://${rawHtmlUrl.hostname}/${segments
-      .slice(0, rawMarker + 3)
-      .join('/')}/`
-  }
-
-  return undefined
-}
 
 export function sanitizeRelativePath(
   pathParam: string | undefined,

--- a/src/utils/lang/html.ts
+++ b/src/utils/lang/html.ts
@@ -126,7 +126,7 @@ function normalizePathname(pathname: string): string {
   return `/${normalized.join('/')}`
 }
 
-function getRepositoryRoot(url: URL): string {
+export function getRepositoryRoot(url: URL): string {
   const pathname = normalizePathname(url.pathname)
   const segments = pathname.split('/').filter(Boolean)
 

--- a/src/utils/preview.ts
+++ b/src/utils/preview.ts
@@ -19,7 +19,6 @@ export class Preview {
 
   // Session
   resources: Record<string, string> = {}
-  currentPageUrl: URL | undefined
 
   // TODO - might be worth memoizing against the URL for the session
   pageData: Partial<HTMLPageData> = {}
@@ -93,7 +92,6 @@ export class Preview {
     }
 
     const { processedHTML, title } = processHTML(data, url)
-    this.currentPageUrl = new URL(url)
 
     this.pageData.title = title ?? url
 
@@ -262,18 +260,22 @@ export class Preview {
     this.iframeDocument.document.head.appendChild(tag)
   }
 
-  private async appendExternalScriptToHead(
+  private appendExternalScriptToHead(
     src: string,
     type?: 'module',
   ): Promise<void> {
-    const tag = this.iframeDocument.document.createElement('script')
+    return new Promise<void>((resolve, reject) => {
+      const tag = this.iframeDocument.document.createElement('script')
 
-    if (type) {
-      tag.type = type
-    }
+      if (type) {
+        tag.type = type
+      }
 
-    tag.src = src
-    this.iframeDocument.document.head.appendChild(tag)
+      tag.onload = () => resolve()
+      tag.onerror = () => reject(new Error(`Failed to load script: ${src}`))
+      tag.src = src
+      this.iframeDocument.document.head.appendChild(tag)
+    })
   }
 
   /**


### PR DESCRIPTION
Fix script loading race condition, deduplicate `getRepositoryRoot` function, and remove unused `currentPageUrl` property to improve preview reliability and code quality.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the preview script loading flow to wait for external script load/error events, which could affect render timing and failure modes. Also centralizes `getRepositoryRoot` logic, so incorrect URL handling could impact GitHub/GitLab asset fallback resolution.
> 
> **Overview**
> Improves preview reliability by **eliminating a script loading race**: external `<script src=...>` tags appended to the iframe head are now awaited via `onload`/`onerror` before dispatching `DOMContentLoaded`.
> 
> Deduplicates repository-root URL parsing by moving `getRepositoryRoot` into `lang/html.ts` (and reusing it from `image-fallback.ts`), and removes the unused `Preview.currentPageUrl` field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50aaad52cc80169a37fff5622fae387e5cd4fd78. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->