### PR TITLE
Set up dev environment + clarify Node 24 gotcha

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@
 
 - The `prepare` script (`svelte-kit sync`) runs automatically during `npm install`. If you see import errors for `$app/*` modules, re-run `npm install`.
 - The dev server uses Vite's default port **5173**. Pass `--host 0.0.0.0` to expose it outside localhost: `npm run dev -- --host 0.0.0.0`.
-- Requires **Node.js >= 24** (`engines` field in `package.json`). Use `nvm use 24` if multiple versions are installed.
+- Requires **Node.js >= 24** (`engines` field in `package.json`, `engine-strict=true` in `.npmrc`, so `npm install` fails on older Node). The VM ships a Node v22 at `/exec-daemon/node` that can shadow nvm. In a login shell `nvm use 24` prepends Node 24 correctly; if `node -v` still shows v22, prepend nvm's bin explicitly: `export PATH="$(dirname "$(nvm which 24)"):$PATH"`.
 - Preview functionality uses the internal `/api/proxy` endpoint. Configure `PROXY_ALLOWED_ORIGINS` with deployment origins (comma separated) to restrict CORS.
 - `svelte-preprocess` deprecation warnings about "defaults" are expected and harmless.
 - The `package-lock.json` uses npm; do not mix with other package managers.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Set up the Cursor Cloud development environment for Static Preview (client-side SvelteKit app) and verified all dev workflows work end to end on Node 24.

The only code change is a docs clarification in `AGENTS.md`: the VM ships a Node v22 at `/exec-daemon/node` that can shadow nvm, and `engine-strict=true` in `.npmrc` makes `npm install` fail on Node < 24. The note now explains how to reliably select Node 24.

## Verification

- `npm install` (Node 24)
- `npm run lint` — Prettier + ESLint clean
- `npm run test` — 7 suites, 58 tests passing
- `npm run check` — 0 errors, 0 warnings
- `npm run build` — built successfully
- `npm run dev` — served on `http://localhost:5173`; entered `https://github.com/octocat/Spoon-Knife` and the static site rendered from GitHub via the `/api/proxy` endpoint.

<a href="https://cursor.com/agents/bc-a7a4e7de-a036-40a8-8d1a-ad650a521103/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstatic_preview_hello_world_demo.mp4"><img src="https://cursor.com/artifacts/c/art-2499a6b7-09c1-4faa-8c05-ea0f1fef2d67" alt="static_preview_hello_world_demo.mp4" /></a>

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a7a4e7de-a036-40a8-8d1a-ad650a521103"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a7a4e7de-a036-40a8-8d1a-ad650a521103"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

